### PR TITLE
fix for modern docker engines

### DIFF
--- a/service/Dockerfile
+++ b/service/Dockerfile
@@ -1,7 +1,7 @@
 FROM node
-
-ADD package.json .
+WORKDIR /app
+COPY package.json package.json
 RUN npm install
-ADD . .
+COPY . .
 
 ENTRYPOINT ["npm", "start"]


### PR DESCRIPTION
You have a folder called bin, since you don't specify a workdir you would cull the base image's /bin directory, which docker disapproves.